### PR TITLE
add 'awfact' argument to 'calc_asfr'

### DIFF
--- a/R/fertility.R
+++ b/R/fertility.R
@@ -7,6 +7,9 @@
 #' @param agegr break points for age groups in completed years of age.
 #' @param period break points for calendar year periods (possibly non-integer).
 #' @param tips break points for TIme Preceding Survey.
+#' @param awfact Variable name for all women factor (character string).
+#' @param awfact_scale Scale for `awfact` variable values. Default is 100
+#'   as is used in DHS recode files.
 #' @param bhdata A birth history dataset (`data.frame`) with child dates of birth
 #'   in long format.
 #' @param varmethod Method for variance calculation. Currently "lin" for Taylor
@@ -87,27 +90,36 @@ calc_asfr <- function(data,
                       dob="v011",
                       intv = "v008",
                       weight= "v005",
+                      awfact = NULL,
                       varmethod = "lin",
                       bvars = grep("^b3\\_[0-9]*", names(data), value=TRUE),
                       birth_displace = 1e-6,
                       origin=1900,
                       scale=12,
+                      awfact_scale = 100,
                       bhdata = NULL,
                       counts=FALSE,
                       clustcounts = FALSE){
-  
+
   data$id <- data[[id]]
   data$dob <- data[[dob]]
   data$intv <- data[[intv]]
   data$weights <- data[[weight]] / mean(data[[weight]])
 
+  if (!is.null(awfact)) {
+    data$awfact <- data[[awfact]] / awfact_scale
+  } else {
+    data$awfact <- 1
+  }
+
   if(is.null(by))
     by <- ~1
-  
+
   vars <- unique(unlist(lapply(c(by, strata, clusters), all.vars)))
   f <- formula(paste("~", paste(vars, collapse = "+")))
   mf <- model.frame(formula = f, data = data, na.action = na.pass,
-                    id = id, weights = weights, dob = dob, intv = intv)
+                    id = id, weights = weights, dob = dob, intv = intv,
+                    awfact = awfact)
 
   if(is.null(bhdata)) {
     births <- model.frame(paste("~", paste(bvars, collapse="+")),
@@ -133,10 +145,26 @@ calc_asfr <- function(data,
 
   epis <- tmerge(mf, mf, id=id_, tstart=`(dob)`, tstop=`(intv)`)
   epis <- tmerge(epis, births, id=id_, birth = event(bcmc))
-  
-  aggr <- demog_pyears(f, epis, period=period, agegr=agegr, cohort=cohort, tips=tips,
-                       event="birth", weights="(weights)", origin=origin, scale=scale)$data
-  
+
+  pyears_args <- list(f, data=epis, period=period, agegr=agegr, cohort=cohort, tips=tips,
+                      event="birth", weights="(weights)", origin=origin, scale=scale)
+  aggr <- do.call(demog_pyears, args = pyears_args)$data
+
+  # replace 'pyears' (denominator) with 'pyears' accounting for awfact
+  if (length(unique(epis$`(awfact)`)) > 1) {
+    # calculate pyears using weights * awfact
+    # https://dhsprogram.com/data/Guide-to-DHS-Statistics/Analyzing_DHS_Data.htm
+    epis$`(weights)` <- epis$`(weights)` * epis$`(awfact)`
+    pyears_args$data <- epis
+    aggr_pyears <- do.call(demog_pyears, args = pyears_args)$data
+
+    # replace pyears with recalculation using weights * awfacct
+    aggr_id_vars <- setdiff(names(aggr), c("pyears", "n", "event"))
+    aggr_pyears[c("n", "event")] <- NULL
+    aggr[c("pyears")] <- NULL
+    aggr <- merge(aggr, aggr_pyears, by = aggr_id_vars, all = TRUE)
+  }
+
   ## construct interaction of all factor levels that appear
   byvar <- intersect(c(all.vars(by), "agegr", "period", "cohort", "tips"),
                      names(aggr))
@@ -230,13 +258,15 @@ calc_tfr <- function(data,
                      dob = "v011",
                      intv = "v008",
                      weight = "v005",
+                     awfact = NULL,
                      varmethod = "lin",
                      bvars = grep("^b3\\_[0-9]*", names(data), value=TRUE),
                      birth_displace = 1e-6,
                      origin = 1900,
                      scale = 12,
+                     awfact_scale = 100,
                      bhdata = NULL){
-  
+
   g <- match.call()
   g[[1]] <- quote(calc_asfr)
   g$data <- data

--- a/man/calc_asfr.Rd
+++ b/man/calc_asfr.Rd
@@ -18,11 +18,13 @@ calc_asfr(
   dob = "v011",
   intv = "v008",
   weight = "v005",
+  awfactt = NULL,
   varmethod = "lin",
   bvars = grep("^b3\\\\_[0-9]*", names(data), value = TRUE),
   birth_displace = 1e-06,
   origin = 1900,
   scale = 12,
+  awfactt_scale = 100,
   bhdata = NULL,
   counts = FALSE,
   clustcounts = FALSE
@@ -35,12 +37,17 @@ calc_asfr(
 
 \item{tips}{break points for TIme Preceding Survey.}
 
+\item{awfactt}{Variable name for all women factor (character string).}
+
 \item{varmethod}{Method for variance calculation. Currently "lin" for Taylor
 linearisation, "jk1" for unstratified jackknife, "jkn" for stratified
 jackknife, or "none" for no variance estimate.}
 
 \item{bvars}{Names of variables giving child dates of birth. If \code{bhdata} is
 provided, then length(bvars) must equal 1.}
+
+\item{awfactt_scale}{Scale for \code{awfactt} variable values. Default is 100
+as is used in DHS recode files.}
 
 \item{bhdata}{A birth history dataset (\code{data.frame}) with child dates of birth
 in long format.}

--- a/tests/testthat/test_dhsrates.R
+++ b/tests/testthat/test_dhsrates.R
@@ -1,6 +1,7 @@
 context("Demographic rate outputs")
 
 library(demogsurv)
+library(rdhs)
 
 data(zzir)
 data(zzbr)
@@ -11,7 +12,56 @@ test_that("fertility calculations match DHS tables", {
   expect_equal(round(1000*as.numeric(calc_asfr(zzir)$asfr)),
                c(119, 207, 216, 188, 125, 60, 28))
 })
- 
+
+test_that("fertility calculations match DHS tables when only ever married women surveyed", {
+
+  # load data from 1989-1990 Sudan DHS
+  surveys <- rdhs::dhs_surveys(countryIds = "SD", surveyYear = 1990, surveyType = "DHS")
+  testthat::skip_if_not(
+    nrow(surveys) == 1,
+    message = "Unable to test fertility calculations with `awfact` argument due to not having access to 1990 SDN DHS"
+  )
+
+  ird <- rdhs::dhs_datasets(fileType = "IR", fileFormat = "flat")
+  ird <- ird[ird$SurveyId %in% surveys$SurveyId,]
+  brd <- rdhs::dhs_datasets(fileType = "BR", fileFormat = "flat")
+  brd <- brd[brd$SurveyId %in% surveys$SurveyId,]
+
+  rdhs::get_datasets(ird$FileName)
+  rdhs::get_datasets(brd$FileName)
+
+  ird_vars <- c("caseid", "v005", "v008", "v011", "v001", "v101", "v102", "awfactt", "awfactu")
+  ird_questions <- rdhs::search_variables(ird$FileName, variables = ird_vars)
+  brd_vars <- c("caseid", "bidx", "b3")
+  brd_questions <- rdhs::search_variables(brd$FileName, variables = brd_vars)
+
+  ir <- rdhs::extract_dhs(ird_questions, add_geo = FALSE)
+  br <- rdhs::extract_dhs(brd_questions, add_geo = FALSE)
+
+  ## Convert to factors (a bit inefficient)
+  ir <- lapply(ir, haven::as_factor)
+  br <- lapply(br, haven::as_factor)
+
+  # expected values from final report
+  # https://dhsprogram.com/publications/publication-FR36-DHS-Final-Reports.cfm
+  calc_args <- list(
+    data = ir$SDIR02FL, bhdata = br$SDBR02FL,
+    clusters = ~v001, strata = ~v101 + v102, bvars = "b3",
+    tips = c(0, 5),
+    awfact = "awfactt"
+  )
+  # table 3.1 TFR 0-4 years prior to survey for total
+  expect_equal(round(as.numeric(do.call(calc_tfr, calc_args)$tfr), 1), 5.0)
+  # table 3.2/3.3 ASFR 0-4 years prior to survey
+  expect_equal(round(1000*as.numeric(do.call(calc_asfr, calc_args)$asfr)),
+               c(69, 183, 240, 236, 157, 82, 25))
+
+  # table 3.1 TFR 0-4 years prior to survey for urban/rural residences
+  calc_args[["by"]] <- ~v102
+  calc_args[["awfact"]] <- "awfactu"
+  expect_equal(round(as.numeric(do.call(calc_tfr, calc_args)$tfr), 1), c(4.1, 5.6))
+})
+
 
 test_that("child mortality calculations work", {
   zzbr$death <- zzbr$b5 == "no"  # b5: child still alive ("yes"/"no")


### PR DESCRIPTION
Hi @jeffeaton.

This PR accounts for the DHS all women factors used to adjust ever-married samples to estimate statistics based on all women as described [here](https://dhsprogram.com/data/Guide-to-DHS-Statistics/index.htm#t=Analyzing_DHS_Data.htm%23All_Women_Factorsbc-5). The assumption for the asfr calculation is that never-married women that are usually eligible for the women's questionnaire in standard DHS surveys have had 0 children.

I added a test that uses `rdhs` to download the Sudan 1990 DHS data and compares to the report values. Thoughts on using `rdhs` in the package tests? I also added a line to skip the test if the developer does not have access to that survey or does not have a rdhs config set up.

This passed all tests on my local machine but should still fail the github action checks since it does not include the commits from https://github.com/mrc-ide/demogsurv/pull/9.

Thanks!