### PR TITLE
allow user-specified death variable name in calc_nqx()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: demogsurv
 Title: Demographic analysis of DHS and other household surveys
-Version: 0.2.3
+Version: 0.2.4
 Authors@R: c(person("Jeff", "Eaton", email = "jeffrey.eaton@imperial.ac.uk", role = c("aut", "cre")),
              person("Bruno", "Masquelier", email = "bruno.masquelier@uclouvain.be", role = "aut"))
 Description: This package includes tools for calculating demographic indicators from household

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# demogsurv 0.2.4
+
+* Bugfix in `calc_nqx()` to allow user-specified column name for death outcome variable (issue #11; thanks @JoseAntonioOrtega).
+
 # demogsurv 0.2.3
 
 * Internal fix `calc_asfr()` to address `tmerge()` error: `idname option must be a valid variable name`.

--- a/R/child-mortality.R
+++ b/R/child-mortality.R
@@ -81,6 +81,7 @@ calc_nqx <- function(data,
   data$tstop <- ifelse(data[[death]], data[[dod]], data[[intv]])
 
   data$dob <- data[[dob]]
+  data$death <- data[[death]]
   data$intv <- data[[intv]]
   data$weights <- data[[weight]] / mean(data[[weight]])
 

--- a/tests/testthat/test_dhsrates.R
+++ b/tests/testthat/test_dhsrates.R
@@ -22,7 +22,25 @@ test_that("child mortality calculations work", {
   expect_equal(round(c(calc_nqx(zzbr, by=~v102, tips=c(0, 5))$est), 3),
                c(0.153, 0.135))
 })
- 
+
+test_that("user can specify arbitrary variable names for event args", {
+
+  ## Rename death variable "d"
+  zzbr$death <- NULL
+  zzbr$d <- zzbr$b5 == "no"
+
+  zzbr$dod <- NULL
+  zzbr$dod_approx <- zzbr$b3 + zzbr$b7 + 0.5
+
+  zzbr$DOB <- zzbr$b3
+  zzbr$b3 <- NULL
+
+  zzbr$intv_cmc <- zzbr$v008
+  zzbr$v008 <- NULL
+
+  u5mr <- calc_nqx(zzbr, dob = "DOB", dod = "dod_approx", death = "d", intv = "intv_cmc")
+  expect_equal(round(u5mr$est, 3), c(0.221, 0.194, 0.141))
+})
 
 test_that("adult mortality calculation reproduce DHS tables", {
   zzsib <- reshape_sib_data(zzir)


### PR DESCRIPTION
Patch for #11 . Thanks @JoseAntonioOrtega.