### PR TITLE
Move 'batch_size' argument usage to `demog_pyears` function.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,4 +31,4 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 VignetteBuilder: knitr
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1

--- a/R/fertility.R
+++ b/R/fertility.R
@@ -98,10 +98,11 @@ calc_asfr <- function(data,
                       birth_displace = 1e-6,
                       origin=1900,
                       scale=12,
+                      batch_size = 100000,
                       bhdata = NULL,
                       counts=FALSE,
                       clustcounts = FALSE){
-  
+
   data$id <- data[[id]]
   data$dob <- data[[dob]]
   data$intv <- data[[intv]]
@@ -146,8 +147,9 @@ calc_asfr <- function(data,
   epis <- tmerge(epis, births, id=id_, birth = event(bcmc))
   
   aggr <- demog_pyears(f, epis, period=period, agegr=agegr, cohort=cohort, tips=tips,
-                       event="birth", weights="(weights)", origin=origin, scale=scale)$data
-  
+                       event="birth", weights="(weights)",
+                       origin=origin, scale=scale, batch_size=batch_size)
+
   ## construct interaction of all factor levels that appear
   byvar <- intersect(c(all.vars(by), "agegr", "period", "cohort", "tips"),
                      names(aggr))
@@ -246,8 +248,9 @@ calc_tfr <- function(data,
                      birth_displace = 1e-6,
                      origin = 1900,
                      scale = 12,
+                     batch_size = 100000,
                      bhdata = NULL){
-  
+
   g <- match.call()
   g[[1]] <- quote(calc_asfr)
   g$data <- data

--- a/man/calc_asfr.Rd
+++ b/man/calc_asfr.Rd
@@ -23,6 +23,7 @@ calc_asfr(
   birth_displace = 1e-06,
   origin = 1900,
   scale = 12,
+  batch_size = 1e+05,
   bhdata = NULL,
   counts = FALSE,
   clustcounts = FALSE
@@ -66,6 +67,10 @@ by. Default is '1e-6'.}
 \item{origin}{Origin year for date arguments. 1900 for CMC inputs.}
 
 \item{scale}{Scale for dates inputs to calendar years. 12 for CMC inputs.}
+
+\item{batch_size}{Maximum number of data rows to process at one time
+in \code{demog_pyears()}. Default value 100,000. This avoids memory allocation
+error when processing for very large data set (e.g. India DHS).}
 
 \item{bhdata}{A birth history dataset (\code{data.frame}) with child dates of birth
 in long format, for example a DHS births recode (BR) dataset.}

--- a/man/calc_nqx.Rd
+++ b/man/calc_nqx.Rd
@@ -59,7 +59,7 @@ jackknife.}
 
 \item{scale}{Scale for dates inputs to calendar years. 12 for CMC inputs.}
 
-\item{batch_size}{Maximum number of data rows to to process at one time
+\item{batch_size}{Maximum number of data rows to process at one time
 in \code{demog_pyears()}. Default value 100,000. This avoids memory allocation
 error when processing for very large data set (e.g. India DHS).}
 }

--- a/man/demog_pyears.Rd
+++ b/man/demog_pyears.Rd
@@ -18,7 +18,8 @@ demog_pyears(
   tstart = "tstart",
   tstop = "tstop",
   event = "event",
-  weights = NULL
+  weights = NULL,
+  batch_size = 1e+05
 )
 }
 \arguments{
@@ -72,6 +73,10 @@ birth or death. Default is 'event'.}
 \item{weights}{
     case weights. 
   }
+
+\item{batch_size}{Maximum number of data rows to process at one time
+in \code{demog_pyears()}. Default value 100,000. This avoids memory allocation
+error when processing for very large data set (e.g. India DHS).}
 }
 \description{
 This is a wrapper for the \code{\link[survival]{pyears}} function

--- a/vignettes/demogsurv-methods.Rmd
+++ b/vignettes/demogsurv-methods.Rmd
@@ -106,7 +106,7 @@ The mortality rate $mu_a$ within each age group is estimated as the number
 of observed deaths divided by the number of person-years.
 
 ```{r mx}
-mx <- aggr$data
+mx <- aggr
 mx$agegr <- paste(c(0, "1-2", "3-5", "6-11", "12-23", "24-35", "36-47", "48-59"), "months")
 mx$mx <- mx$event / mx$pyears
 knitr::kable(mx)


### PR DESCRIPTION
Hi Jeff.

Similar to #15 I was getting an error when trying to calculate fertility rates from large surveys. 

I saw [this commit message](https://github.com/mrc-ide/demogsurv/commit/2bd0433ace6b5b51cad4b469f35e1ad19f8dc733) and attempted the refactor to use `batch_size` within the `demog_pyears` function. I also added the `batch_size` argument to `calc_asfr` and `calc_tfr`.

If you think users are directly using `demog_pyears` we could add an argument like `data.frame=FALSE` to preserve the original return format by default?

This was the original error I was getting in my use case.
```
Error in pyears(formula, data, scale = scale, data.frame = TRUE, weights = weights) :
  long vectors (argument 11) are not supported in .C
```

I tested that this passed the package checks on my local machine